### PR TITLE
add platform x86_64-linux

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.3-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.3-x86_64-linux)
+      racc (~> 1.4)
     public_suffix (4.0.6)
     puma (5.6.2)
       nio4r (~> 2.0)
@@ -209,6 +211,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)


### PR DESCRIPTION
I was facing and issue to deploy to Heroku. It was giving me the `Failed to install gems via Bundler` error. And reading the error I found that my bundle only supports platforms ["x86_64-darwin-21"] but my local platform
remote: was x86_64-linux. So I did: `bundle lock --add-platform x86_64-linux`. Hopefully it will work.